### PR TITLE
Convert parent_path & path to str before concatenation

### DIFF
--- a/usnjrnl_rewind.py
+++ b/usnjrnl_rewind.py
@@ -95,7 +95,7 @@ def get_full_path(entry, lookup_dict, path):
         else:
             parent_path = get_full_path(parent_entry, lookup_dict, parent_name)
     if path:
-        return parent_path + '\\' + path
+        return str(parent_path) + '\\' + str(path)
     return parent_path
 
 def create_journal_rewind_csv(sqlite_db_path, out_csv_path, mft_table_name, usn_table_name):


### PR DESCRIPTION
Hello!

It appears that if an entry is a number, Python will implicitly cast it to an integer, resulting in a unhandled error when the parent path and the entry path are concatenated:

```
Traceback (most recent call last):
  File "XXX\usnjrnl_rewind\usnjrnl_rewind.py", line 312, in <module>
    main()
  File "XXX\usnjrnl_rewind\usnjrnl_rewind.py", line 309, in main
    rewind(output_path, mft_csv_path, usnjrnl_csv_path)
  File "XXX\usnjrnl_rewind\usnjrnl_rewind.py", line 79, in rewind
    create_journal_rewind_csv(sqlite_path, out_csv_path, 'MFT', 'USNJRNL')
  File "XXX\usnjrnl_rewind\usnjrnl_rewind.py", line 245, in create_journal_rewind_csv
    path_prefix = get_full_path(parent_entry, parent_lookup, parent_file_name)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "XXX\usnjrnl_rewind\usnjrnl_rewind.py", line 98, in get_full_path
    return parent_path + '\\' + path
           ~~~~~~~~~~~~~~~~~~~^~~~~~
TypeError: can only concatenate str (not "int") to str
```

This commit fixes that error by explicitly casting the parent path and the entry path to strings before the concatenation.