### PR TITLE
Fix ADS names in paths and stale parent names after renames

### DIFF
--- a/usnjrnl_rewind.py
+++ b/usnjrnl_rewind.py
@@ -128,12 +128,16 @@ def get_full_path(entry, lookup_dict, path):
     parent_path = "<UNKNOWN>"
     if entry in lookup_dict:
         file_name, parent_entry, parent_name = lookup_dict[entry]
+        # Use the current name from the dict rather than the caller's
+        # cached copy, which may be stale after rename events update
+        # parent_lookup during the reverse-chronological walk.
+        path = file_name
         if parent_entry == "5-5":
             parent_path = "."
         else:
             parent_path = get_full_path(parent_entry, lookup_dict, parent_name)
     if path:
-        # If parent is number, python may treat as int, not str, hence explicit 
+        # If parent is number, python may treat as int, not str, hence explicit
         # conversion to string below
         return str(parent_path) + '\\' + str(path)
     return parent_path
@@ -217,6 +221,10 @@ def create_journal_rewind_csv(sqlite_db_path, out_csv_path, mft_table_name, usn_
     parent_lookup = {} # { Entry : (EntryName, ParentEntry, ParentName), .. }
 
     for result in results:
+        # Skip ADS entries — their names contain ':' (e.g. "$UpCase:$Info")
+        # and would overwrite the real filename for the same Entry key.
+        if ':' in result['FileName']:
+            continue
         parent_lookup[result['Entry']] = (result['FileName'], result['ParentEntry'], result['ParentName'])
 
     query = '''


### PR DESCRIPTION
## Summary

First — thank you for publishing the Rewind algorithm. The idea of replaying the journal in reverse to reconstruct point-in-time paths is elegant, and it directly inspired the path resolution engine in [usnjrnl-forensic](https://github.com/SecurityRonin/usnjrnl-forensic).

While validating usnjrnl-forensic against usnjrnl_rewind across 757,491 USN records from 3 publicly available forensic disk images, I found two path resolution bugs that account for ~6% incorrect paths (45,751 records). Full validation report [here](https://github.com/SecurityRonin/usnjrnl-forensic/blob/main/docs/VALIDATION.md).

### Bug 1: ADS entries overwrite real filenames in parent_lookup

The MFT query produces multiple rows for the same Entry key when alternate data streams exist (the comment on lines 205-207 already notes this). Since `parent_lookup` is a dict keyed by Entry, the last row wins — if the ADS row comes after the base row, the directory name includes the stream suffix (e.g. `Microsoft Office:Win32App_1` instead of `Microsoft Office`).

**Fix:** Skip filenames containing `:` when populating parent_lookup.

### Bug 2: Stale parent names in recursive path resolution

`get_full_path()` uses the `path` parameter passed by the caller (from the cached `parent_name` in each tuple) rather than looking up the entry's current name from the dict. After rename events update `parent_lookup` during the reverse-chronological walk, the cached `parent_name` in other entries' tuples becomes stale.

For example, when a directory is renamed or moved to the Recycle Bin at USN X, the rename event correctly updates `parent_lookup`. But other entries whose tuples still reference the old `parent_name` will produce incorrect paths for events before USN X.

**Fix:** In `get_full_path()`, use `file_name` from the dict lookup instead of the passed-in `path` when the entry is found.

### Per-image disagreement rates (before fix)

| Image | Total records | Disagreements | Agreement |
|-------|--------------|---------------|-----------|
| [Szechuan Sauce](https://cfreds.nist.gov/all/DigitalCorpora/LoneWolfScenario) | 117,498 | 32 | 99.97% |
| [Max Powers](https://cfreds.nist.gov/all/SANS/HolidayHackChallenge2018) | 369,498 | 36,685 | 90.09% |
| [PC-MUS](https://cfreds.nist.gov/all/MagnetForensics/MagnetVirtualSummitCTF2019) | 270,495 | 9,034 | 96.66% |

Full reproduction steps in the [validation report](https://github.com/SecurityRonin/usnjrnl-forensic/blob/main/docs/VALIDATION.md#reproduction).